### PR TITLE
Remove EOL ruby-sass

### DIFF
--- a/feathericon-sass.gemspec
+++ b/feathericon-sass.gemspec
@@ -16,6 +16,6 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-  s.add_runtime_dependency 'sass', '>= 3.2'
-  s.add_development_dependency 'sass-rails'
+  s.add_runtime_dependency 'sassc', '>= 2.0'
+  s.add_development_dependency 'sassc-rails'
 end


### PR DESCRIPTION
feathericon-sass depends on Ruby Sass, but Ruby Sass is [EOL](https://sass-lang.com/ruby-sass). It's no longer supported.
This pull request replaces Ruby Sass with Sassc.

[Sassc and Libsass are also deprecated](https://sass-lang.com/blog/libsass-is-deprecated), but not yet EOL. I think this is a better choice.