### PR TITLE
add woff2 format into font-face

### DIFF
--- a/app/assets/stylesheets/feathericon.css
+++ b/app/assets/stylesheets/feathericon.css
@@ -12,6 +12,7 @@
   src: font-url('feathericon.eot');
   src: font-url('feathericon.eot?#iefix') format('embedded-opentype'),
     font-url('feathericon.woff') format('woff'),
+    font-url('feathericon.woff2') format('woff2'),
     font-url('feathericon.ttf') format('truetype'),
     font-url('feathericon.svg') format('svg');
   font-weight: normal;


### PR DESCRIPTION
There is 'woff2' format file in fonts directory, but it's not imported in @font-face in feathericon.css.
So that I added it and made it imported. I would be glad if you check and merge.