### PR TITLE
set font-display property

### DIFF
--- a/app/assets/stylesheets/feathericon.css
+++ b/app/assets/stylesheets/feathericon.css
@@ -16,6 +16,7 @@
     font-url('feathericon.svg') format('svg');
   font-weight: normal;
   font-style: normal;
+  font-display: block;
  }
 
 


### PR DESCRIPTION
I set font-display: block; into feathericon's @font-face.

## Background
I found that feathericon-sass's file loading is costing time a little.
Google introduces the way to shorten font loading time by setting font-display property into @font-face,
so I suggest to introduce this solution into feathericon.

Here is the reference about it.
[How to avoid showing invisible text | google web.dev](https://web.dev/font-display/?utm_source=lighthouse&utm_medium=unknown#how-to-avoid-showing-invisible-text)

## Supplement
The documentation above introduces font-display: swap; as a solution for text font, by displaying alternative font during loading.
However, in the case of icon font, which has no alternative font, font-display: block; is the optimal solution. It displays blanc object during loading.
Reference: [font-display #the_font_display_timeline | MDN](https://developer.mozilla.org/en-US/docs/Web/CSS/@font-face/font-display#the_font_display_timeline)

For your refference, other open source icon font FontAwesome adopts font-display: block; , too.
[https://github.com/FortAwesome/Font-Awesome/blob/fcec2d1b01ff069ac10500ac42e4478d20d21f4c/css/all.css#L4590](https://github.com/FortAwesome/Font-Awesome/blob/fcec2d1b01ff069ac10500ac42e4478d20d21f4c/css/all.css#L4590)